### PR TITLE
fix: resolve PostgreSQL port conflicts and service startup order

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="MavenProjectsManager">

--- a/ai-helper-service/Dockerfile
+++ b/ai-helper-service/Dockerfile
@@ -1,5 +1,7 @@
 FROM openjdk:17-jdk-slim
 WORKDIR /app
-COPY target/*.jar app.jar
+ARG JAR_FILE=target/*.jar
+COPY ${JAR_FILE} app.jar
 EXPOSE 8084
+RUN apt-get update && apt-get install -y netcat-traditional wget
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/api-gateway/Dockerfile
+++ b/api-gateway/Dockerfile
@@ -1,5 +1,7 @@
 FROM openjdk:17-jdk-slim
 WORKDIR /app
-COPY target/*.jar app.jar
+ARG JAR_FILE=target/*.jar
+COPY ${JAR_FILE} app.jar
 EXPOSE 8080
+RUN apt-get update && apt-get install -y netcat-traditional wget
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/design-pattern-catalog-service/Dockerfile
+++ b/design-pattern-catalog-service/Dockerfile
@@ -1,5 +1,7 @@
 FROM openjdk:17-jdk-slim
 WORKDIR /app
-COPY target/*.jar app.jar
+ARG JAR_FILE=target/*.jar
+COPY ${JAR_FILE} app.jar
 EXPOSE 8082
+RUN apt-get update && apt-get install -y netcat-traditional wget
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   service-registry:
     build:
@@ -8,66 +7,94 @@ services:
       - "8761:8761"
     networks:
       - app-network
+    depends_on:
+      - postgres-user
+      - postgres-catalog
+    volumes:
+      - ./wait-for-it.sh:/wait-for-it.sh
+    command: ["sh", "-c", "chmod +x /wait-for-it.sh && /wait-for-it.sh postgres-user 5432 /wait-for-it.sh postgres-catalog 5432 java -jar app.jar"]
+
   user-management-service:
     build:
       context: ./user-management-service
       dockerfile: Dockerfile
     ports:
       - "8081:8081"
-    depends_on:
-      - service-registry
     networks:
       - app-network
-  design-pattern-catalog-service:
-    build:
-      context: ./design-pattern-catalog-service
-      dockerfile: Dockerfile
-    ports:
-      - "8082:8082"
     depends_on:
       - service-registry
-    networks:
-      - app-network
+    volumes:
+      - ./wait-for-it.sh:/wait-for-it.sh
+    command: ["sh", "-c", "chmod +x /wait-for-it.sh && /wait-for-it.sh service-registry 8761 java -jar app.jar"]
+
   recommendation-engine-service:
     build:
       context: ./recommendation-engine-service
       dockerfile: Dockerfile
     ports:
       - "8083:8083"
-    depends_on:
-      - service-registry
     networks:
       - app-network
+    depends_on:
+      - user-management-service
+    volumes:
+      - ./wait-for-it.sh:/wait-for-it.sh
+    command: ["sh", "-c", "chmod +x /wait-for-it.sh && /wait-for-it.sh user-management-service 8081 java -jar app.jar"]
+
   ai-helper-service:
     build:
       context: ./ai-helper-service
       dockerfile: Dockerfile
     ports:
       - "8084:8084"
-    depends_on:
-      - service-registry
     networks:
       - app-network
+    depends_on:
+      - recommendation-engine-service
+    volumes:
+      - ./wait-for-it.sh:/wait-for-it.sh
+    command: ["sh", "-c", "chmod +x /wait-for-it.sh && /wait-for-it.sh recommendation-engine-service 8083 java -jar app.jar"]
+
+  design-pattern-catalog-service:
+    build:
+      context: ./design-pattern-catalog-service
+      dockerfile: Dockerfile
+    ports:
+      - "8082:8082"
+    networks:
+      - app-network
+    depends_on:
+      - ai-helper-service
+    volumes:
+      - ./wait-for-it.sh:/wait-for-it.sh
+    command: ["sh", "-c", "chmod +x /wait-for-it.sh && /wait-for-it.sh ai-helper-service 8084 java -jar app.jar"]
+
   api-gateway:
     build:
       context: ./api-gateway
       dockerfile: Dockerfile
     ports:
       - "8080:8080"
-    depends_on:
-      - service-registry
     networks:
       - app-network
+    depends_on:
+      - design-pattern-catalog-service
+    volumes:
+      - ./wait-for-it.sh:/wait-for-it.sh
+    command: ["sh", "-c", "chmod +x /wait-for-it.sh && /wait-for-it.sh design-pattern-catalog-service 8082 java -jar app.jar"]
+
   postgres-user:
     image: postgres:latest
     ports:
-      - "5432:5432"
+      - "5434:5432"
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: user_db
     networks:
       - app-network
+
   postgres-catalog:
     image: postgres:latest
     ports:

--- a/recommendation-engine-service/Dockerfile
+++ b/recommendation-engine-service/Dockerfile
@@ -1,5 +1,7 @@
 FROM openjdk:17-jdk-slim
 WORKDIR /app
-COPY target/*.jar app.jar
+ARG JAR_FILE=target/*.jar
+COPY ${JAR_FILE} app.jar
 EXPOSE 8083
+RUN apt-get update && apt-get install -y netcat-traditional wget
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/service-registry/Dockerfile
+++ b/service-registry/Dockerfile
@@ -1,5 +1,7 @@
 FROM openjdk:17-jdk-slim
 WORKDIR /app
-COPY target/*.jar app.jar
+ARG JAR_FILE=target/*.jar
+COPY ${JAR_FILE} app.jar
 EXPOSE 8761
+RUN apt-get update && apt-get install -y netcat-traditional wget
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/start-services.sh
+++ b/start-services.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+# Function to wait for a port to be available with timeout
+wait_for_port() {
+    local host=$1
+    local port=$2
+    local timeout=60  # 60 seconds timeout
+    local start_time=$(date +%s)
+    
+    echo "Waiting for $host:$port..."
+    while ! timeout 1 bash -c "echo > /dev/tcp/$host/$port" 2>/dev/null; do
+        local current_time=$(date +%s)
+        local elapsed=$((current_time - start_time))
+        
+        if [ $elapsed -gt $timeout ]; then
+            echo "Timeout waiting for $host:$port after ${timeout} seconds"
+            echo "Checking container logs..."
+            docker compose logs --tail=50 $(docker compose ps -q | grep $port)
+            exit 1
+        fi
+        
+        echo "Waiting for $host:$port... ($elapsed seconds)"
+        sleep 3
+    done
+    echo "$host:$port is available"
+}
+
+# Start and wait for Postgres
+echo "Starting Postgres instances..."
+docker compose up postgres-user postgres-catalog -d
+wait_for_port localhost 5434  # Changed from 5432
+wait_for_port localhost 5433  # Changed from 5432
+
+# Start and wait for Service Registry
+echo "Starting Service Registry..."
+docker compose up service-registry -d
+wait_for_port localhost 8761
+
+# Start and wait for User Management
+echo "Starting User Management..."
+docker compose up user-management-service -d
+docker compose logs user-management-service  # Added to see startup logs
+wait_for_port localhost 8081
+
+# Start and wait for Design Pattern Catalog
+echo "Starting Design Pattern Catalog..."
+docker compose up design-pattern-catalog-service -d
+docker compose logs design-pattern-catalog-service  # Added to see startup logs
+wait_for_port localhost 8082
+
+# Start and wait for Recommendation Engine
+echo "Starting Recommendation Engine..."
+docker compose up recommendation-engine-service -d
+wait_for_port localhost 8083
+
+# Start and wait for AI Helper
+echo "Starting AI Helper..."
+docker compose up ai-helper-service -d
+wait_for_port localhost 8084
+
+# Start and wait for API Gateway
+echo "Starting API Gateway..."
+docker compose up api-gateway -d
+wait_for_port localhost 8080
+
+echo "All services are up and running!" 

--- a/user-management-service/Dockerfile
+++ b/user-management-service/Dockerfile
@@ -5,10 +5,13 @@ FROM openjdk:17-jdk-slim
 WORKDIR /app
 
 # Copy the JAR file into the container
-COPY target/*.jar app.jar
+ARG JAR_FILE=target/*.jar
+COPY ${JAR_FILE} app.jar
 
 # Expose the port the app runs on
 EXPOSE 8081
+
+RUN apt-get update && apt-get install -y netcat-traditional wget
 
 # Command to run the application
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/wait-for-it.sh
+++ b/wait-for-it.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# wait-for-it.sh
+
+host="$1"
+port="$2"
+shift 2
+cmd="$@"
+
+# First wait for the port to be available
+until nc -z "$host" "$port"; do
+  echo "Waiting for $host:$port..."
+  sleep 3
+done
+
+# For Spring Boot services, wait for the actuator health endpoint
+if [[ $port != "5432" ]]; then  # Skip for postgres
+  until wget -q --spider http://$host:$port/actuator/health; do
+    echo "Waiting for $host:$port to be healthy..."
+    sleep 3
+  done
+  
+  # Check if the service is actually UP
+  until wget -q -O - http://$host:$port/actuator/health | grep -q "UP"; do
+    echo "Waiting for $host:$port to be UP..."
+    sleep 3
+  done
+fi
+
+echo "$host:$port is available and healthy"
+exec $cmd 


### PR DESCRIPTION
- Changed PostgreSQL port mappings to avoid conflicts with local instance
  - User DB: 5434:5432
  - Catalog DB: 5433:5432
- Added start-services.sh script for controlled service startup
  - Implements port availability checking
  - Handles timeout and error logging
  - Ensures proper service initialization order

This resolves issues with:
- Port conflicts between containers and local PostgreSQL
- Service dependency management
- Startup order reliability